### PR TITLE
Enhancements and fixes

### DIFF
--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/AbstractSfgCertificate.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/AbstractSfgCertificate.java
@@ -113,8 +113,8 @@ public abstract class AbstractSfgCertificate extends ApiClient {
 		this.systemCertId = json.getString("systemCertId");
 		this.createdOrUpdatedBy = json.getString("createdOrUpdatedBy");
 		this.creationOrUpdateTime = json.getString("creationOrUpdateTime");
-		this.verifyValidity = json.getJSONObject("verifyValidity").getBoolean("code");
-		this.verifyAuthChain = json.getJSONObject("verifyAuthChain").getBoolean("code");
+		this.verifyValidity = getBooleanCode(json, "verifyValidity");
+		this.verifyAuthChain = getBooleanCode(json, "verifyAuthChain");
 		return this;
 	}
 

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/AbstractSfgKey.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/AbstractSfgKey.java
@@ -44,6 +44,13 @@ public abstract class AbstractSfgKey extends ApiClient {
     this.keyStatusEnabled = keyStatusEnabled;
   }
 
+  protected AbstractSfgKey(String keyName, SshKey sshKey, boolean keyStatusEnabled) throws InvalidKeyException {
+    super();
+    this.keyName = keyName;
+    this.sshKey = sshKey;
+    this.keyStatusEnabled = keyStatusEnabled;
+  }
+
   @Override
   public String getId() {
     return getGeneratedId() == null ? keyName : getGeneratedId();
@@ -65,8 +72,7 @@ public abstract class AbstractSfgKey extends ApiClient {
         throw new ApiException(ike);
       }
     }
-    if (json.has("keyStatusEnabled"))
-      this.keyStatusEnabled = json.getJSONObject("keyStatusEnabled").getBoolean("code");
+    this.keyStatusEnabled = getBooleanCode(json, "keyStatusEnabled");
     this.keyId = json.optString("keyId");
     this.keyFingerPrint = json.optString("keyFingerPrint");
     this.keyLength = json.optInt("keyLength");

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/Community.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/Community.java
@@ -98,13 +98,13 @@ public class Community extends ApiClient {
 	protected Community readJSON(JSONObject json) throws JSONException {
 		super.init(json);
 		this.name = json.getString("name");
-		this.partnersInitiateConnections = json.getJSONObject("partnersInitiateConnections").getBoolean("code");
-		this.partnersListenForConnections = json.getJSONObject("partnersListenForConnections").getBoolean("code");
-		this.ftpListening = json.getJSONObject("ftpListening").getBoolean("code");
-		this.cdListening = json.getJSONObject("cdListening").getBoolean("code");
-		this.sshListening = json.getJSONObject("sshListening").getBoolean("code");
-		this.wsListening = json.getJSONObject("wsListening").getBoolean("code");
-		this.partnerNotificationsEnabled = json.getJSONObject("partnerNotificationsEnabled").getBoolean("code");
+		this.partnersInitiateConnections = getBooleanCode(json, "partnersInitiateConnections");
+		this.partnersListenForConnections = getBooleanCode(json, "partnersListenForConnections");
+		this.ftpListening = getBooleanCode(json, "ftpListening");
+		this.cdListening = getBooleanCode(json, "cdListening");
+		this.sshListening = getBooleanCode(json, "sshListening");
+		this.wsListening = getBooleanCode(json, "wsListening");
+		this.partnerNotificationsEnabled = getBooleanCode(json, "partnerNotificationsEnabled");
 		if (json.has("customProtocols"))
 			setCustomProtocols(json.getString("customProtocols"));
 		return this;

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/Mailbox.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/Mailbox.java
@@ -143,7 +143,7 @@ public class Mailbox extends ApiClient {
     this.description = json.optString(DESCRIPTION);
     this.permissionName = json.optString(PERMISSION);
     if (json.has(MAILBOX_TYPE))
-      this.mailboxType = json.getJSONObject(MAILBOX_TYPE).getString(CODE);
+      this.mailboxType = getStringCode(json, MAILBOX_TYPE);
     this.linkedToMailboxId = json.optInt(LINKED_TO_MAILBOX);
     if (json.has(GROUPS) && !json.getString(GROUPS).isEmpty()) {
       for (String g : json.getString(GROUPS).split(",")) {

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/Property.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/Property.java
@@ -176,7 +176,7 @@ public class Property extends ApiClient {
     if (json.has(PROPERTY_VALUE)) {
       this.propertyValue = json.getString(PROPERTY_VALUE);
     }
-    this.systemDefined = "Y".equalsIgnoreCase(json.getJSONObject(SYSTEM_DEFINED).getString(CODE));
+    this.systemDefined = "Y".equalsIgnoreCase(getStringCode(json, SYSTEM_DEFINED));
     if (json.has(PROPERTY_NODE_VALUE)) {
       setPropertyNodeValueURL(json.getJSONObject(PROPERTY_NODE_VALUE).getString(HREF));
     }

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/PropertyFiles.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/PropertyFiles.java
@@ -160,8 +160,8 @@ public class PropertyFiles extends ApiClient {
       this.lastUpdatedOn = getDate(json.getString("lastUpdatedOn"));
     }
     if (json.has("componentEditable"))
-      this.componentEditable = "Y".equalsIgnoreCase(json.getJSONObject("componentEditable").getString("code"));
-    this.systemDefined = "Y".equalsIgnoreCase(json.getJSONObject("systemDefined").getString(CODE));
+      this.componentEditable = "Y".equalsIgnoreCase(getStringCode(json, "componentEditable"));
+    this.systemDefined = "Y".equalsIgnoreCase(getStringCode(json, "systemDefined"));
     return this;
   }
 

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/SshAuthorizedUserKey.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/SshAuthorizedUserKey.java
@@ -38,6 +38,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import de.denkunddachte.exception.ApiException;
+import de.denkunddachte.ft.SshKey;
 
 public class SshAuthorizedUserKey extends AbstractSfgKey {
   private final static Logger   LOGGER   = Logger.getLogger(SshAuthorizedUserKey.class.getName());
@@ -49,6 +50,10 @@ public class SshAuthorizedUserKey extends AbstractSfgKey {
 
   public SshAuthorizedUserKey(String keyName, String keyString, boolean keyStatusEnabled) throws InvalidKeyException {
     super(keyName, keyString, keyStatusEnabled);
+  }
+
+  public SshAuthorizedUserKey(String keyName, SshKey sshKey, boolean keyStatusEnabled) throws InvalidKeyException {
+    super(keyName, sshKey, keyStatusEnabled);
   }
 
   private SshAuthorizedUserKey(JSONObject json) throws JSONException, ApiException {

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/SshKnownHostKey.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/SshKnownHostKey.java
@@ -64,6 +64,10 @@ public class SshKnownHostKey extends AbstractSfgKey {
   public SshKnownHostKey(String keyName, String keyString, boolean keyStatusEnabled) throws InvalidKeyException {
     super(keyName, keyString, keyStatusEnabled);
   }
+  
+  public SshKnownHostKey(String keyName, SshKey sshKey, boolean keyStatusEnabled) throws InvalidKeyException {
+    super(keyName, sshKey, keyStatusEnabled);
+  }
 
   private SshKnownHostKey(JSONObject json) throws JSONException, ApiException {
     super();
@@ -88,7 +92,7 @@ public class SshKnownHostKey extends AbstractSfgKey {
       }
     }
     if (json.has("keyStatusEnabled"))
-      this.keyStatusEnabled = json.getJSONObject("keyStatusEnabled").getBoolean("code");
+      this.keyStatusEnabled = getBooleanCode(json, "keyStatusEnabled");
 
     this.keyId = json.optString("keyId");
     this.keyFingerPrint = json.optString("keyFingerPrint");

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/SshUserIdentityKey.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/SshUserIdentityKey.java
@@ -45,13 +45,17 @@ public class SshUserIdentityKey extends AbstractSfgKey {
   }
 
   public SshUserIdentityKey(String keyName, String privateKeyData, String passPhrase, boolean keyStatusEnabled) throws InvalidKeyException {
-    super(keyName, null, keyStatusEnabled);
+    super();
+    this.keyName = keyName;
+    this.keyStatusEnabled = keyStatusEnabled;
     this.passPhrase = passPhrase;
     this.privateKeyData = privateKeyData;
   }
 
   public SshUserIdentityKey(String keyName, File sshPrivateKeyFile, String passPhrase, boolean keyStatusEnabled) throws IOException, InvalidKeyException {
-    super(keyName, null, keyStatusEnabled);
+    super();
+    this.keyName = keyName;
+    this.keyStatusEnabled = keyStatusEnabled;
     try (InputStream is = new FileInputStream(sshPrivateKeyFile)) {
       byte[] data = new byte[(int) sshPrivateKeyFile.length()];
       is.read(data);

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/SterlingConnectDirectNode.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/SterlingConnectDirectNode.java
@@ -108,10 +108,10 @@ public class SterlingConnectDirectNode extends ApiClient {
     this.maxRemotelyInitiatedSnodeSessionsAllowed = json.optInt("maxRemotelyInitiatedSnodeSessionsAllowed");
     this.alternateCommInfo = json.optString("alternateCommInfo");
 
-    this.securePlusOptionEnabled = json.getJSONObject("securePlusOption").getString("code").equalsIgnoreCase("ENABLED");
+    this.securePlusOptionEnabled = getStringCode(json, "securePlusOption").equalsIgnoreCase("ENABLED");
     if (securePlusOptionEnabled) {
       if (json.has("securityProtocol")) {
-        this.securityProtocol = TlsVersion.getByCode(json.getJSONObject("securityProtocol").getInt("code"));
+        this.securityProtocol = TlsVersion.getByCode(getIntCode(json, "securityProtocol"));
       } else {
         // API Bug: GET does not return securityProtocol, so assume TLS 1.2
         this.securityProtocol = TlsVersion.TLS_V12;
@@ -131,7 +131,7 @@ public class SterlingConnectDirectNode extends ApiClient {
         }
       }
       if (json.has("requireClientAuthentication")) {
-        this.requireClientAuthentication = json.getJSONObject("requireClientAuthentication").getString("code").equalsIgnoreCase("YES");
+        this.requireClientAuthentication = getStringCode(json, "requireClientAuthentication").equalsIgnoreCase("YES");
       }
     }
     return this;

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/SystemDigitalCertificate.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/SystemDigitalCertificate.java
@@ -83,7 +83,7 @@ public class SystemDigitalCertificate extends AbstractSfgCertificate {
 	@Override
 	protected SystemDigitalCertificate readJSON(JSONObject json) throws JSONException {
 		super.readJSON(json);
-		this.crlCache = json.getJSONObject("crlCache").getBoolean("code");
+		this.crlCache = getBooleanCode(json, "crlCache");
 		return this;
 	}
 

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/TradingPartner.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/TradingPartner.java
@@ -144,7 +144,7 @@ public class TradingPartner extends ApiClient {
     if (city != null)
       json.put("city", city);
     if (code != null)
-      json.put("code", code);
+      json.put(CODE, code);
     json.put("community", communityName);
     json.put("consumerCdConfiguration", (consumerCdConfiguration != null ? consumerCdConfiguration.toJSON() : null));
     json.put("consumerFtpConfiguration", (consumerFtpConfiguration != null ? consumerFtpConfiguration.toJSON() : null));
@@ -197,37 +197,37 @@ public class TradingPartner extends ApiClient {
     super.init(json);
     LOGGER.log(Level.FINEST, "json={0}", json);
     this.partnerName = json.getString("partnerName");
-    this.authenticationType = AuthType.valueOf(json.getJSONObject("authenticationType").getString("code"));
+    this.authenticationType = AuthType.valueOf(getStringCode(json, "authenticationType"));
     this.emailAddress = json.getString("emailAddress");
     this.givenName = json.optString("givenName");
     this.surname = json.optString("surname");
     this.username = json.optString("username");
     this.setCommunityName(json.getString("community"));
     this.phone = json.getString("phone");
-    this.asciiArmor = json.getJSONObject("asciiArmor").getBoolean("code");
+    this.asciiArmor = getBooleanCode(json, "asciiArmor");
     this.addressLine1 = json.getString("addressLine1");
     this.addressLine2 = json.getString("addressLine2");
     this.city = json.getString("city");
-    this.code = json.getString("code");
-    this.countryOrRegion = PartnerRegion.valueOf(json.getJSONObject("countryOrRegion").getString("code"));
-    this.doesRequireCompressedData = json.getJSONObject("doesRequireCompressedData").getBoolean("code");
-    this.doesRequireEncryptedData = json.getJSONObject("doesRequireEncryptedData").getBoolean("code");
-    this.doesRequireSignedData = json.getJSONObject("doesRequireSignedData").getBoolean("code");
-    this.doesUseSSH = json.getJSONObject("doesUseSSH").getBoolean("code");
-    this.useGlobalMailbox = json.getJSONObject("useGlobalMailbox").getBoolean("code");
-    this.keyEnabled = json.getJSONObject("keyEnabled").getBoolean("code");
+    this.code = json.getString(CODE);
+    this.countryOrRegion = PartnerRegion.valueOf(getStringCode(json, "countryOrRegion"));
+    this.doesRequireCompressedData = getBooleanCode(json, "doesRequireCompressedData");
+    this.doesRequireEncryptedData = getBooleanCode(json, "doesRequireEncryptedData");
+    this.doesRequireSignedData = getBooleanCode(json, "doesRequireSignedData");
+    this.doesUseSSH = getBooleanCode(json, "doesUseSSH");
+    this.useGlobalMailbox = getBooleanCode(json, "useGlobalMailbox");
+    this.keyEnabled = getBooleanCode(json, "keyEnabled");
     this.sessionTimeout = json.optInt("sessionTimeout");
     this.stateOrProvince = json.getString("stateOrProvince");
-    this.textMode = json.getJSONObject("textMode").getBoolean("code");
+    this.textMode = getBooleanCode(json, "textMode");
     if (json.has("timeZone")) {
-      this.timeZone = PartnerTimeZone.getByCode(json.getJSONObject("timeZone").getString("code"));
+      this.timeZone = PartnerTimeZone.getByCode(getStringCode(json, "timeZone"));
     } else {
       this.timeZone = DEFAULT_TIMEZONE;
     }
-    this.isInitiatingConsumer = json.getJSONObject("isInitiatingConsumer").getBoolean("code");
-    this.isInitiatingProducer = json.getJSONObject("isInitiatingProducer").getBoolean("code");
-    this.isListeningConsumer = json.getJSONObject("isListeningConsumer").getBoolean("code");
-    this.isListeningProducer = json.getJSONObject("isListeningProducer").getBoolean("code");
+    this.isInitiatingConsumer = getBooleanCode(json, "isInitiatingConsumer");
+    this.isInitiatingProducer = getBooleanCode(json, "isInitiatingProducer");
+    this.isListeningConsumer = getBooleanCode(json, "isListeningConsumer");
+    this.isListeningProducer = getBooleanCode(json, "isListeningProducer");
     this.publicKeyID = json.getString("publicKeyID");
 
     if (authenticationType == AuthType.External) {

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/UserAccount.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/UserAccount.java
@@ -119,7 +119,7 @@ public class UserAccount extends ApiClient {
   }
 
   @Override
-  public JSONObject toJSON() throws JSONException {
+  public JSONObject toJSON() throws JSONException, ApiException {
     JSONObject json = new JSONObject();
     json.put(AUTHENTICATION_HOST, authenticationHost);
     json.put(AUTHENTICATION_TYPE, authenticationType.toString());
@@ -130,8 +130,8 @@ public class UserAccount extends ApiClient {
       }
       json.put(AUTHORIZED_USER_KEYS, a);
     }
-    json.put(EMAIL, usereMail);
-    json.put(GIVEN_NAME, givenName);
+    json.put(EMAIL, Validator.validateEmail(usereMail));
+    json.put(GIVEN_NAME, Validator.validateName(givenName));
     if (!assignedGroups.isEmpty()) {
       JSONArray a = new JSONArray();
       for (String g : assignedGroups.keySet()) {
@@ -153,7 +153,7 @@ public class UserAccount extends ApiClient {
     json.put(POLICY, userPolicy);
     json.put(PREFERRED_LANGUAGE, preferredLanguage.getCode());
     json.put(SESSION_TIMEOUT, (sessionTimeout > 0 ? sessionTimeout : null));
-    json.put(SURNAME, userSurname);
+    json.put(SURNAME, Validator.validateName(userSurname));
     json.put(USER_ID, userId);
     json.put(USER_IDENTITY, userIdentity);
     return json;
@@ -166,7 +166,7 @@ public class UserAccount extends ApiClient {
     this.userSurname = json.optString(SURNAME);
     this.givenName = json.optString(GIVEN_NAME);
     if (json.has(AUTHENTICATION_TYPE))
-      this.authenticationType = AuthType.valueOf(json.getJSONObject(AUTHENTICATION_TYPE).getString(CODE));
+      this.authenticationType = AuthType.valueOf(getStringCode(json, AUTHENTICATION_TYPE));
 
     this.usereMail = json.optString(EMAIL);
     if (json.has(GROUPS)) {
@@ -182,7 +182,7 @@ public class UserAccount extends ApiClient {
       }
     }
     if (json.has(PREFERRED_LANGUAGE))
-      this.preferredLanguage = UserLanguage.getByCode(json.getJSONObject(PREFERRED_LANGUAGE).getString(CODE));
+      this.preferredLanguage = UserLanguage.getByCode(getStringCode(json, PREFERRED_LANGUAGE));
     this.sessionTimeout = json.optInt(SESSION_TIMEOUT);
     this.userIdentity = json.optString(USER_IDENTITY);
     if (json.has(AUTHORIZED_USER_KEYS)) {
@@ -221,16 +221,16 @@ public class UserAccount extends ApiClient {
     return usereMail;
   }
 
-  public void setEmail(String email) {
-    this.usereMail = email;
+  public void setEmail(String email) throws ApiException {
+    this.usereMail = Validator.validateEmail(email);
   }
 
-  public String getGivenName() {
-    return givenName;
+  public String getGivenName() throws ApiException {
+    return Validator.validateName(givenName);
   }
 
-  public void setGivenName(String givenName) {
-    this.givenName = givenName;
+  public void setGivenName(String givenName) throws ApiException {
+    this.givenName = Validator.validateName(givenName);
   }
 
   public String getManagerId() {

--- a/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/Validator.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sfgapi/Validator.java
@@ -1,0 +1,65 @@
+package de.denkunddachte.sfgapi;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import de.denkunddachte.exception.ApiException;
+import de.denkunddachte.util.ApiConfig;
+
+public abstract class Validator {
+  private static final Logger  LOGGER                  = Logger.getLogger(Validator.class.getName());
+
+  private static final Pattern EMAIL_PATTERN           = Pattern.compile("[a-zA-Z0-9]+([._-][0-9a-zA-Z]+)*@[a-zA-Z0-9]+([.-][0-9a-zA-Z]+)*\\.[a-zA-Z]{2,}");
+  private static final Pattern API000175_INVALID_CHARS = Pattern.compile("[!@#%^*()+?,<>{}\\[\\]|;\"'/\\\\.]");
+  private static ApiConfig     apicfg;
+
+  static {
+    try {
+      apicfg = ApiConfig.getInstance();
+    } catch (ApiException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private Validator() {
+  }
+
+  public static String validateEmail(String email) throws ApiException {
+    if (email != null && !email.trim().isEmpty() && !EMAIL_PATTERN.matcher(email).matches()) {
+      final String template = apicfg.getAutofixEmailTemplate();
+      if (apicfg.isAutofix()) {
+        LOGGER.log(Level.WARNING, "AUTOFIX: replace invalid email address {0} with {1}.", new Object[] { email, template });
+        return template;
+      }
+      throw new ApiException("Invalid email address: " + email + "!");
+    }
+    return email;
+  }
+
+  public static String validateName(String str) throws ApiException {
+    if (str == null || str.trim().isEmpty())
+      return str;
+
+    Matcher      m        = API000175_INVALID_CHARS.matcher(str);
+    StringBuffer sb       = new StringBuffer();
+    boolean      modified = false;
+    while (m.find()) {
+      if (!apicfg.isAutofix()) {
+        throw new ApiException("Name string \"" + str + "\" contain invalid characters " + API000175_INVALID_CHARS.pattern() + "!");
+      }
+      m.appendReplacement(sb, " ");
+      modified = true;
+    }
+
+    if (modified) {
+      m.appendTail(sb);
+      LOGGER.log(Level.WARNING, "AUTOFIX: replace invalid name string \"{0}\" with \"{1}\".", new Object[] { str, sb });
+      return sb.toString();
+    } else {
+      return str;
+    }
+  }
+
+}

--- a/B2BApiClient/src/main/java/de/denkunddachte/sspcmapi/AbstractSspApiClient.java
+++ b/B2BApiClient/src/main/java/de/denkunddachte/sspcmapi/AbstractSspApiClient.java
@@ -64,8 +64,6 @@ public abstract class AbstractSspApiClient implements AutoCloseable {
   private static final String    APPLICATION_XML     = "application/xml";
   protected static final String  X_AUTHENTICATION    = "X-Authentication";
   protected static final String  X_PASSPHRASE        = "X-Passphrase";
-  public static final String     API_DRYRUN_PROPERTY = "apiclient.dryrun";
-  protected static final boolean DRYRUN              = Boolean.parseBoolean(System.getProperty(API_DRYRUN_PROPERTY));
 
   public enum RequestType {
     GET, POST, PUT, DELETE
@@ -152,7 +150,7 @@ public abstract class AbstractSspApiClient implements AutoCloseable {
 
   private XmlResponse doPost(String svc, String method, String object, String data) throws ApiException {
     LOGGER.log(Level.FINEST, "doPost() service={0}, method={1}, object={2}, data:\n{3}", new Object[] { svc, method, object, data });
-    if (!SESSIONSVC.equals(svc) && DRYRUN) {
+    if (!SESSIONSVC.equals(svc) && apicfg.isDryrun()) {
       LOGGER.log(Level.INFO, "DRY RUN: Skip operation={0}, method={1}, object={2}.", new Object[] { "POST", method, object });
       LOGGER.log(Level.FINER, "DRY RUN: data: {0}.", data);
       return new XmlResponse(HttpStatus.SC_OK, "DRY-RUN", true);
@@ -180,7 +178,7 @@ public abstract class AbstractSspApiClient implements AutoCloseable {
 
   private XmlResponse doPut(String svc, String method, String object, String data) throws ApiException {
     LOGGER.log(Level.FINEST, "doPut() service={0}, method={1}, object={2}, data:\n{3}", new Object[] { svc, method, object, data });
-    if (DRYRUN) {
+    if (apicfg.isDryrun()) {
       LOGGER.log(Level.INFO, "DRY RUN: Skip operation={0}, method={1}, object={2}.", new Object[] { "PUT", method, object });
       LOGGER.log(Level.FINER, "DRY RUN: data: {0}.", data);
       return new XmlResponse(HttpStatus.SC_OK, "DRY-RUN", true);
@@ -208,7 +206,7 @@ public abstract class AbstractSspApiClient implements AutoCloseable {
 
   private XmlResponse doDelete(String svc, String method, String object) throws ApiException {
     LOGGER.log(Level.FINEST, "doDelete() service={0}, method={1}, object={2}", new Object[] { svc, method, object });
-    if (DRYRUN) {
+    if (apicfg.isDryrun()) {
       LOGGER.log(Level.INFO, "DRY RUN: Skip operation={0}, method={1}, object={2}.", new Object[] { "DELETE", method, object });
       return new XmlResponse(HttpStatus.SC_OK, "DRY-RUN", true);
     }

--- a/B2BApiClient/src/main/resources/apiconfig-sample.properties
+++ b/B2BApiClient/src/main/resources/apiconfig-sample.properties
@@ -49,7 +49,7 @@ wfd.refreshWfdCache=false
 
 #------------------------------------------------------------------------------
 # Remote BP executor (implement as local/remote process if DD_API_WS is not available)
-# In IIM installations, call workflowLauncher.sh directly (or via ssh, sudo or both). 
+# In IIM installations, call workflowLauncher.sh directly (or via ssh, sudo or both).
 # Use @args as placeholder for generated arguments. If not present, arguments are appended to command.
 # NOTE: "executebp" api must not be included in sfgapi.wsapilist!
 # e.g. ssh -p <ssh port> <b2bihost> "cd /tmp; sudo -u <b2biuser> -- /path/to/b2bi/bin/workflowLauncher.sh -u <runas user> @args"

--- a/B2BUtils/src/main/java/de/denkunddachte/b2biutil/AbstractConsoleApp.java
+++ b/B2BUtils/src/main/java/de/denkunddachte/b2biutil/AbstractConsoleApp.java
@@ -121,6 +121,9 @@ public abstract class AbstractConsoleApp implements AutoCloseable {
     }
 
     // reinitialize logger (settings might have changed in config and/or commandline)
+    if (cfg.hasProperty("log.file") ) {
+      cfg.setProperty("log.level", cfg.getString(LogConfig.PROP_LOG_STDERR));
+    }
     LogConfig.initConfig();
 
     LOG.log(Level.FINE, "Start {0} {1}", new Object[] { OPTIONS.getProgramName(), String.join(" ", args) });

--- a/JavaTaskHelper/src/main/java/de/denkunddachte/b2biutils/JavaTask.java
+++ b/JavaTaskHelper/src/main/java/de/denkunddachte/b2biutils/JavaTask.java
@@ -28,6 +28,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.Arrays;
@@ -400,6 +403,9 @@ public final class JavaTask {
             sb.append(line.replaceAll("^\\s*//\\s*", ""));
           } else if (line.contains("<ProcessData>")) {
             sb = new StringBuilder(line);
+          } else if (line.contains("ProcessDataFile:")) {
+            File f = new File(line.replaceAll(".*ProcessDataFile:\\s*(.+)\\s*$", "$1"));
+            return new String(Files.readAllBytes(Paths.get(f.toURI())), Charset.forName("UTF-8"));
           }
           if (line.contains("</ProcessData>")) {
             break;
@@ -438,6 +444,11 @@ public final class JavaTask {
             sb = new StringBuilder(line.replaceAll(".*PrimaryDocumentData:\\s*(.+)\\s*$", "$1"));
             if (sb.length() > 0) {
               sb.append(System.lineSeparator());
+            }
+          } else if (line.contains("PrimaryDocumentFile:")) {
+            File f = new File(line.replaceAll(".*PrimaryDocumentFile:\\s*(.+)\\s*$", "$1"));
+            if (f.exists()) {
+              return new Document(f);
             }
           } else {
             if (sb != null) {

--- a/ddutils/src/main/java/de/denkunddachte/utils/Config.java
+++ b/ddutils/src/main/java/de/denkunddachte/utils/Config.java
@@ -411,6 +411,7 @@ public class Config {
     for (String key : getKeys(prefix)) {
       map.put(key, props.get(key));
     }
+    map.put(PROP_CONFIG_FILE, loadedResources);
     return map;
   }
 
@@ -419,6 +420,7 @@ public class Config {
     for (String key : getKeys(prefix)) {
       map.put(key, String.valueOf(props.get(key)));
     }
+    map.put(PROP_CONFIG_FILE, loadedResources.get(loadedResources.size()-1));
     return map;
   }
 


### PR DESCRIPTION
- improve cache and dry-run handling: dry run is now set in ApiConfig and cache mechanism allows update/delete on local cache
- support code elements as JSONObject or primitive values (JSON structure differs for GET and POST/PUT operations)
- add constructors for keys with SshKey objects
- add some validations for fields where SFG dashboard validations are more lax that REST API (email, names). More might be necessary...
- Add autofix option for said fields to allow get and update operations
- fixes in WorkflowDefinition API
- JavaTaskHelper: add comment tags to source process data and primary document from file